### PR TITLE
fix: base 設定調整

### DIFF
--- a/assets/components/layout/_header.scss
+++ b/assets/components/layout/_header.scss
@@ -85,6 +85,14 @@
       }
     }
   }
+  &.user-state,
+  &.login-state {
+    @include media-breakpoint-up(md) {
+      .both-state-md-none {
+        display: none !important;
+      }
+    }
+  }
 }
 
 .header-offcanvas.offcanvas {
@@ -112,11 +120,6 @@
     --bs-btn-hover-bg: #{$primary-300};
     --bs-btn-active-border-color: #{$primary-800};
   }
-}
-
-// work around
-.text-left {
-  text-align: left;
 }
 
 .dropdown-shadow {

--- a/layout/footer.ejs
+++ b/layout/footer.ejs
@@ -3,7 +3,7 @@
     <div class="d-flex flex-column flex-md-row justify-content-md-between align-items-md-center mb-8">
       <!-- 標題 -->
       <div class="text-center text-md-start mb-8 mb-md-0">
-        <a href="/cardle-vanilla/pages/index.html" class="mb-4 mb-md-2">
+        <a href="<%= HERF_BASE %>index.html" class="mb-4 mb-md-2">
           <img src="/assets/images/logo-with-text.svg" alt="logo" />
         </a>
         <p class="text-primary fw-bold fs-s">把靈感放進卡片盒，慢慢長成知識的森林。</p>
@@ -11,13 +11,13 @@
       <!-- 導覽連結 -->
       <ul class="nav nav-pills flex-column flex-md-row align-items-center gap-3">
         <li class="nav-item">
-          <a class="nav-link" href="/cardle-vanilla/pages/index.html">首頁</a>
+          <a class="nav-link" href="<%= HERF_BASE %>index.html">首頁</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="/cardle-vanilla/pages/features.html">產品介紹</a>
+          <a class="nav-link" href="<%= HERF_BASE %>features.html">產品介紹</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="/cardle-vanilla/pages/subscription/detail.html">訂閱方案</a>
+          <a class="nav-link" href="<%= HERF_BASE %>subscription/detail.html">訂閱方案</a>
         </li>
       </ul>
     </div>

--- a/layout/header.ejs
+++ b/layout/header.ejs
@@ -1,6 +1,6 @@
 <nav class="header-navbar navbar navbar-expand-md bg-gray-0 border-bottom border-primary-100 pe-0">
   <div class="container">
-    <a href="/cardle-vanilla/pages/index.html">
+    <a href="<%= HERF_BASE %>index.html">
       <h2 class="logo">Cardle</h2>
     </a>
     <button
@@ -16,21 +16,19 @@
     <div class="offcanvas flex-row align-items-center justify-content-end">
       <ul class="navbar-nav gap-2">
         <li class="nav-item user-none">
-          <a class="nav-link rounded-2 py-2 px-4 active" aria-current="page" href="/cardle-vanilla/pages/index.html"
-            >首頁</a
-          >
+          <a class="nav-link rounded-2 py-2 px-4 active" aria-current="page" href="<%= HERF_BASE %>index.html">首頁</a>
         </li>
         <li class="nav-item user-none">
-          <a class="nav-link rounded-2 py-2 px-4" href="/cardle-vanilla/pages/features.html">商品介紹</a>
+          <a class="nav-link rounded-2 py-2 px-4" href="<%= HERF_BASE %>features.html">商品介紹</a>
         </li>
         <li class="nav-item user-none">
-          <a class="nav-link rounded-2 py-2 px-4" href="/cardle-vanilla/pages/subscription/detail.html">訂閱方案</a>
+          <a class="nav-link rounded-2 py-2 px-4" href="<%= HERF_BASE %>subscription/detail.html">訂閱方案</a>
         </li>
         <li class="login-none user-none">
-          <a class="btn btn-outline-primary" href="/cardle-vanilla/pages/login.html">登入</a>
+          <a class="btn btn-outline-primary" href="<%= HERF_BASE %>login.html">登入</a>
         </li>
         <li class="login-none user-none">
-          <a class="btn btn-primary" href="/cardle-vanilla/pages/sing-up.html">免費註冊</a>
+          <a class="btn btn-primary" href="<%= HERF_BASE %>sing-up.html">免費註冊</a>
         </li>
         <!-- 登入後 dropdown -->
         <li class="login-show">
@@ -47,13 +45,13 @@
             </button>
             <ul class="dropdown-shadow dropdown-menu border-primary-400 bg-gray-0">
               <li>
-                <a class="dropdown-item rounded-2 mb-2" href="/cardle-vanilla/pages/user/dashboard.html">筆記儀表板</a>
+                <a class="dropdown-item rounded-2 mb-2" href="<%= HERF_BASE %>user/dashboard.html">筆記儀表板</a>
               </li>
               <li>
-                <a class="dropdown-item rounded-2 mb-2" href="/cardle-vanilla/pages/user/booklists.html">我的書單</a>
+                <a class="dropdown-item rounded-2 mb-2" href="<%= HERF_BASE %>user/booklists.html">我的書單</a>
               </li>
               <li>
-                <a class="dropdown-item rounded-2 mb-2" href="/cardle-vanilla/pages/user/account.html">會員中心</a>
+                <a class="dropdown-item rounded-2 mb-2" href="<%= HERF_BASE %>user/account.html">會員中心</a>
               </li>
               <li><a class="dropdown-item rounded-2" id="logout-btn" href="#">登出</a></li>
             </ul>
@@ -77,25 +75,25 @@
               style="height: calc(100vh - 73px)"
             >
               <li>
-                <a class="dropdown-item rounded-2 mb-2" href="/cardle-vanilla/pages/user/booklists.html">我的書單</a>
+                <a class="dropdown-item rounded-2 mb-2" href="<%= HERF_BASE %>user/booklists.html">我的書單</a>
               </li>
               <li>
-                <a class="dropdown-item rounded-2 mb-2" href="/cardle-vanilla/pages/user/dashboard.html">卡片盒一覽</a>
+                <a class="dropdown-item rounded-2 mb-2" href="<%= HERF_BASE %>user/dashboard.html">卡片盒一覽</a>
               </li>
               <li>
-                <a class="dropdown-item rounded-2 mb-2" href="/cardle-vanilla/pages/user/dashboard.html">關聯地圖</a>
+                <a class="dropdown-item rounded-2 mb-2" href="<%= HERF_BASE %>user/dashboard.html">關聯地圖</a>
               </li>
               <li class="border-bottom border-gray-200 mb-2">
-                <a class="dropdown-item rounded-2 mb-2" href="/cardle-vanilla/pages/user/dashboard.html">我的草稿</a>
+                <a class="dropdown-item rounded-2 mb-2" href="<%= HERF_BASE %>user/dashboard.html">我的草稿</a>
               </li>
               <li>
-                <a class="dropdown-item rounded-2 mb-2" href="/cardle-vanilla/pages/user/dashboard.html">個人首頁</a>
+                <a class="dropdown-item rounded-2 mb-2" href="<%= HERF_BASE %>user/dashboard.html">個人首頁</a>
               </li>
               <li>
-                <a class="dropdown-item rounded-2 mb-2" href="/cardle-vanilla/pages/user/account.html">會員中心</a>
+                <a class="dropdown-item rounded-2 mb-2" href="<%= HERF_BASE %>user/account.html">會員中心</a>
               </li>
               <li>
-                <a class="dropdown-item rounded-2 mb-2" href="/cardle-vanilla/pages/user/account/plan-upgrade.html"
+                <a class="dropdown-item rounded-2 mb-2" href="<%= HERF_BASE %>user/account/plan-upgrade.html"
                   >升級方案</a
                 >
               </li>
@@ -109,7 +107,7 @@
     </div>
     <!-- 登入後 mobile offcanvas 按鈕 -->
     <button
-      class="navbar-toggler p-0 border-0 rounded-circle focus-ring ms-4"
+      class="login-show user-show both-state-md-none navbar-toggler p-0 border-0 rounded-circle focus-ring ms-4"
       type="button"
       data-bs-toggle="offcanvas"
       data-bs-target="#userNavbar"
@@ -132,21 +130,19 @@
   <div class="offcanvas-body p-2 border border-primary-400">
     <ul class="navbar-nav me-auto mb-6">
       <li class="nav-item">
-        <a class="nav-link rounded-2 py-3 px-4 active" aria-current="page" href="/cardle-vanilla/pages/index.html"
-          >首頁</a
-        >
+        <a class="nav-link rounded-2 py-3 px-4 active" aria-current="page" href="<%= HERF_BASE %>index.html">首頁</a>
       </li>
       <li class="nav-item">
-        <a class="nav-link rounded-2 py-3 px-4" href="/cardle-vanilla/pages/features.html">商品介紹</a>
+        <a class="nav-link rounded-2 py-3 px-4" href="<%= HERF_BASE %>features.html">商品介紹</a>
       </li>
       <li class="nav-item">
-        <a class="nav-link rounded-2 py-3 px-4" href="/cardle-vanilla/pages/subscription/detail.html">訂閱方案</a>
+        <a class="nav-link rounded-2 py-3 px-4" href="<%= HERF_BASE %>subscription/detail.html">訂閱方案</a>
       </li>
     </ul>
-    <span class="login-none border-bottom border-gray-200 mb-6 mx-2_5 d-block"></span>
-    <div class="login-none d-flex flex-column">
-      <a class="btn btn-outline-primary text-left py-3 mb-2" href="/cardle-vanilla/pages/login.html">登入</a>
-      <a class="btn btn-primary text-left py-3" href="/cardle-vanilla/pages/sing-up.html">免費註冊</a>
+    <span class="login-none user-none border-bottom border-gray-200 mb-6 mx-2_5 d-block"></span>
+    <div class="login-none user-none d-flex flex-column">
+      <a class="btn btn-outline-primary text-start py-3 mb-2" href="<%= HERF_BASE %>login.html">登入</a>
+      <a class="btn btn-primary text-start py-3" href="<%= HERF_BASE %>sing-up.html">免費註冊</a>
     </div>
   </div>
 </div>
@@ -162,19 +158,17 @@
   <div class="offcanvas-body p-2 border border-primary-400">
     <ul class="navbar-nav me-auto mb-6">
       <li class="nav-item">
-        <a class="nav-link text-primary rounded-2 py-3 px-4 mb-2" href="/cardle-vanilla/pages/user/dashboard.html"
+        <a class="nav-link text-primary rounded-2 py-3 px-4 mb-2" href="<%= HERF_BASE %>user/dashboard.html"
           >筆記儀表板</a
         >
       </li>
       <li class="nav-item">
-        <a class="nav-link text-primary rounded-2 py-3 px-4 mb-2" href="/cardle-vanilla/pages/user/booklists.html"
+        <a class="nav-link text-primary rounded-2 py-3 px-4 mb-2" href="<%= HERF_BASE %>user/booklists.html"
           >我的書單</a
         >
       </li>
       <li class="nav-item">
-        <a class="nav-link text-primary rounded-2 py-3 px-4 mb-2" href="/cardle-vanilla/pages/user/account.html"
-          >會員中心</a
-        >
+        <a class="nav-link text-primary rounded-2 py-3 px-4 mb-2" href="<%= HERF_BASE %>user/account.html">會員中心</a>
       </li>
       <li class="nav-item"><a class="nav-link text-primary rounded-2 py-3 px-4" id="logout-btn" href="#">登出</a></li>
     </ul>
@@ -215,10 +209,10 @@
   const logoutBtns = document.querySelectorAll('#logout-btn');
 
   logoutBtns.forEach((btn) => {
-    btn.addEventListener('click', () => {
-      console.log('logout');
+    btn.addEventListener('click', (event) => {
+      event.preventDefault();
       localStorage.removeItem('isLogin');
-      window.location.href = '/cardle-vanilla/pages/index.html';
+      window.location.href = '<%= HERF_BASE %>index.html';
       updateHeaderState();
     });
   });

--- a/pages/index.html
+++ b/pages/index.html
@@ -16,9 +16,7 @@
         <div class="d-flex flex-column justify-content-center px-7_5 px-md-0 h-100">
           <h1 class="fs-3xl fs-md-6xl mb-4 mb-md-8">卡片紀錄想法，讓知識自在成長</h1>
           <p class="fw-bold fs-l fs-md-3xl mb-8">把靈感拆解、連結、重組，打造專屬你的知識地圖。</p>
-          <a
-            href="/cardle-vanilla/pages/sing-up.html"
-            class="btn btn-primary align-self-md-start fs-md-xl py-md-4 px-md-6"
+          <a href="<%= HERF_BASE %>sing-up.html" class="btn btn-primary align-self-md-start fs-md-xl py-md-4 px-md-6"
             >立即開始</a
           >
         </div>
@@ -853,9 +851,7 @@
                         </ul>
                       </div>
                       <!-- CTA 按鈕 -->
-                      <a
-                        href="/cardle-vanilla/pages/sing-up.html"
-                        class="btn btn-outline-gray-400 py-md-4 mt-auto w-100"
+                      <a href="<%= HERF_BASE %>sing-up.html" class="btn btn-outline-gray-400 py-md-4 mt-auto w-100"
                         >立即註冊</a
                       >
                     </div>

--- a/pages/login.html
+++ b/pages/login.html
@@ -48,7 +48,7 @@
               <label class="form-check-label" for="radioDefault1"> Default radio </label>
             </div>
             <button type="submit" class="btn btn-primary w-100 mt-4">登入</button>
-            <p>新會員？<a href="../pages/sing-up.html">註冊</a></p>
+            <p>新會員？<a href="<%= HERF_BASE %>sing-up.html">註冊</a></p>
           </form>
         </div>
       </div>
@@ -63,7 +63,7 @@
       loginForm.addEventListener('submit', (event) => {
         event.preventDefault();
         localStorage.setItem('isLogin', 'true');
-        window.location.href = 'user/dashboard.html';
+        window.location.href = '<%= HERF_BASE %>user/dashboard.html';
       });
     </script>
   </body>

--- a/pages/sing-up.html
+++ b/pages/sing-up.html
@@ -125,7 +125,7 @@
           <!-- 立即登入 -->
           <p class="fw-medium">
             已經有Cardle帳號了？
-            <a href="/cardle-vanilla/pages/login.html" class="text-decoration-underline link-secondary link-offset-1"
+            <a href="<%= HERF_BASE %>login.html" class="text-decoration-underline link-secondary link-offset-1"
               >立即登入</a
             >
           </p>
@@ -186,7 +186,7 @@
               <span class="material-symbols-outlined fill align-middle text-secondary fs-4xl me-2"> check_circle </span
               >註冊成功！
             </h1>
-            <a href="../pages/login.html" class="btn-close p-2_5"></a>
+            <a href="<%= HERF_BASE %>login.html" class="btn-close p-2_5"></a>
             <!-- <button type="button" class="btn-close p-2_5" data-bs-dismiss="modal" aria-label="Close"></button> -->
           </div>
           <div class="modal-body">
@@ -196,7 +196,7 @@
             </div>
           </div>
           <div class="modal-footer border-top-0">
-            <a href="../pages/login.html" class="btn btn-primary py-md-4 w-100">確認</a>
+            <a href="<%= HERF_BASE %>login.html" class="btn btn-primary py-md-4 w-100">確認</a>
             <!-- <button type="button" class="btn btn-primary py-md-4 w-100" data-bs-dismiss="modal">確認</button> -->
           </div>
         </div>

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,20 +1,20 @@
-import { defineConfig } from "vite";
-import { ViteEjsPlugin } from "vite-plugin-ejs";
-import liveReload from "vite-plugin-live-reload"; // 監聽 .ejs 變動，提供熱更新
-import { fileURLToPath } from "node:url";
-import path from "node:path";
-import { glob } from "glob"; // 多頁的書出口
+import { defineConfig } from 'vite';
+import { ViteEjsPlugin } from 'vite-plugin-ejs';
+import liveReload from 'vite-plugin-live-reload'; // 監聽 .ejs 變動，提供熱更新
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { glob } from 'glob'; // 多頁的書出口
 
 // 自訂 plugin 移除輸出檔案的 'pages'
 const moveOutputPlugin = () => {
   return {
-    name: "move-output",
-    enforce: "post",
-    apply: "build",
+    name: 'move-output',
+    enforce: 'post',
+    apply: 'build',
     async generateBundle(options, bundle) {
       for (const fileName in bundle) {
-        if (fileName.startsWith("pages/")) {
-          const newFileName = fileName.slice("pages/".length);
+        if (fileName.startsWith('pages/')) {
+          const newFileName = fileName.slice('pages/'.length);
           bundle[fileName].fileName = newFileName;
         }
       }
@@ -23,42 +23,40 @@ const moveOutputPlugin = () => {
 };
 
 // vite 專案設定
-export default defineConfig({
-  // 對應靜態網站部屬時的子資料夾
-  base: "/cardle-vanilla/",
-  plugins: [
-    // 指定熱更新的監聽檔案
-    liveReload([
-      "./layout/**/*.ejs",
-      "./pages/**/*.ejs",
-      "./components/**/*.ejs",
-      "./page/**/*.html",
-    ]),
-    // 讓 .html 支援 <%= ... %> EJS 模板語法
-    ViteEjsPlugin(),
-    moveOutputPlugin(),
-  ],
-  // 指定啟動 dev server 時打開的檔案
-  server: {
-    open: "pages/index.html",
-  },
-  build: {
-    rollupOptions: {
-      // 轉換成 Rollup 的入口清單
-      input: Object.fromEntries(
-        // 找到所有 pages 的 HTML
-        glob
-          .sync("pages/**/*.html")
-          .map((file) => [
-            path.relative(
-              "pages",
-              file.slice(0, file.length - path.extname(file).length)
-            ),
-            fileURLToPath(new URL(file, import.meta.url)),
-          ])
-      ),
+export default defineConfig(({ command }) => {
+  const isDev = command === 'serve';
+  const base = isDev ? '/' : '/cardle-vanilla/';
+
+  return {
+    base: process.env.NODE_ENV === 'production' ? '/cardle-vanilla/' : '/', // 對應靜態網站部屬時的子資料夾
+    plugins: [
+      // 指定熱更新的監聽檔案
+      liveReload(['./layout/**/*.ejs', './pages/**/*.ejs', './components/**/*.ejs', './page/**/*.html']),
+      // 讓 .html 支援 <%= ... %> EJS 模板語法
+      ViteEjsPlugin({
+        HERF_BASE: isDev ? '/pages/' : base, // dev 用 /pages/，build 用 /cardle-vanilla/
+      }),
+      moveOutputPlugin(),
+    ],
+    // 指定啟動 dev server 時打開的檔案
+    server: {
+      open: 'pages/index.html',
     },
-    // 輸出到 dist 資料夾
-    outDir: "dist",
-  },
+    build: {
+      rollupOptions: {
+        // 轉換成 Rollup 的入口清單
+        input: Object.fromEntries(
+          // 找到所有 pages 的 HTML
+          glob
+            .sync('pages/**/*.html')
+            .map((file) => [
+              path.relative('pages', file.slice(0, file.length - path.extname(file).length)),
+              fileURLToPath(new URL(file, import.meta.url)),
+            ])
+        ),
+      },
+      // 輸出到 dist 資料夾
+      outDir: 'dist',
+    },
+  };
 });


### PR DESCRIPTION
調整 vite.config 的 defineConfig 設定：
- 依環境調整 base：` base: process.env.NODE_ENV === 'production' ? '/cardle-vanilla/' : '/',`
- ViteEjsPlugin 新增 EJS 參數 `HERF_BASE` 來依環境調整基礎路徑：`HERF_BASE: isDev ? '/pages/' : base,`

先在都可以讓開發與部屬的連結路徑皆正確編譯，路徑撰寫範例：
```
<a href="<%= HERF_BASE %>index.html"> // 到首頁
<a class="nav-link rounded-2 py-2 px-4" href="<%= HERF_BASE %>subscription/detail.html">  // 到訂閱方案
<a class="dropdown-item rounded-2 mb-2" href="<%= HERF_BASE %>user/dashboard.html">  // 到筆記儀表板
```